### PR TITLE
Skip lines when scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ max_length = -1,          -- Maximum length (in ms) of a command. The line delay
                           -- re-calculated. Setting to -1 will disable this option.
 scroll_limit = 150,       -- Max number of lines moved before scrolling is skipped. Setting
                           -- to -1 will disable this option.
+smallest_delay_per_frame = 0.5, -- Smallest delay of one frame when scrolling. If the delay
+                                -- would be shorter than this (when scrolling many lines),
+                                -- then multiple lines are scrolled in order to get a
+                                -- faster scrolling. Slower terminal emulators probably need
+                                -- a larger value.
 ```
 
 ### Example Configuration

--- a/lua/cinnamon/config.lua
+++ b/lua/cinnamon/config.lua
@@ -11,4 +11,5 @@ return {
   horizontal_scroll = true,
   max_length = -1,
   scroll_limit = 150,
+  smallest_delay_per_frame = 0.5,
 }

--- a/lua/cinnamon/scroll.lua
+++ b/lua/cinnamon/scroll.lua
@@ -133,7 +133,7 @@ M.scroll = function(command, scroll_win, use_count, delay_length, deprecated_arg
   -- Calculate the delay length.
   if config.max_length ~= -1 then
     if math.abs(distance) * delay_length > config.max_length then
-      delay_length = math.floor((config.max_length / math.abs(distance)) + 0.5)
+      delay_length = config.max_length / math.abs(distance)
     end
   end
 


### PR DESCRIPTION
Hey!

This is related to the other feature request I made here: https://github.com/declancm/cinnamon.nvim/issues/10

The maximum delay helped me a bit, but I would still like to have scrolling for larger files. Right now, if I scroll without setting `max_length`, then the result is still a pretty slow scroll:

https://user-images.githubusercontent.com/9450943/180608694-a4766a34-e922-43dd-90f9-7175b9c72199.mov

With my changes, if the total scrolling would take too long (configured with `max_length`), then the scrolling skips some lines until a minimum delay (currently hard-coded).

https://user-images.githubusercontent.com/9450943/180608892-5c5de037-309c-4800-9ba9-072aba4bd7aa.mov

To me, this snappy smooth scrolling looks pretty good 😄

Currently, the `smallest_delay` (0.5ms) is just a random value that looks okay for me. But I think that a good value for this depends on the rendering speed of the terminal. A larger `smallest_delay` would probably be needed for slower terminals, otherwise, the animation would still take longer than desired (since the terminal can take more time to render the screen than the delay would be).

This PR is pretty WIP though, I'm not sure what should be configurable for the user and if my additions are clear enough.

Let me know what you think of this idea!